### PR TITLE
dev-rust/rust-bindgen: new ebuild

### DIFF
--- a/dev-rust/rust-bindgen/files/rust-bindgen
+++ b/dev-rust/rust-bindgen/files/rust-bindgen
@@ -1,0 +1,2 @@
+#!/bin/sh
+LD_PRELOAD="/usr/lib/libclang.so" rust-bindgen-9999 "$@"

--- a/dev-rust/rust-bindgen/metadata.xml
+++ b/dev-rust/rust-bindgen/metadata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer>
+		<email>void@asdasd.ru</email>
+	</maintainer>
+</pkgmetadata>

--- a/dev-rust/rust-bindgen/rust-bindgen-9999.ebuild
+++ b/dev-rust/rust-bindgen/rust-bindgen-9999.ebuild
@@ -1,0 +1,38 @@
+# Copyright 1999-2014 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+inherit eutils git-r3
+
+DESCRIPTION="A binding generator for the rust language"
+HOMEPAGE="https://github.com/crabtw/rust-bindgen"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS=""
+
+IUSE=""
+
+EGIT_REPO_URI="git://github.com/crabtw/rust-bindgen.git"
+
+DEPEND=">=virtual/rust-999
+	dev-rust/cargo
+	>=sys-devel/clang-3.4.2-r100
+"
+RDEPEND="${DEPEND}"
+
+src_configure() {
+	true
+}
+
+src_compile() {
+	cargo build --release
+}
+
+src_install() {
+	install -D -m 755 "${FILESDIR}/rust-bindgen" "${D}/usr/bin/rust-bindgen"
+	install -D -m 755 target/release/bindgen "${D}/usr/bin/rust-bindgen-9999"
+	install -D -t "${D}/usr/lib" target/release/libbindgen*
+}


### PR DESCRIPTION
Rust-bindgen is a highly useful tool, so let's add the ebuild.
