### PR TITLE
new ebuild for cargo (cargo-9999-r1.ebuild)

### DIFF
--- a/dev-rust/cargo/cargo-9999-r1.ebuild
+++ b/dev-rust/cargo/cargo-9999-r1.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2014 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+inherit eutils git-r3
+
+DESCRIPTION="A Rust's package manager"
+HOMEPAGE="http://crates.io/"
+
+LICENSE="|| ( MIT Apache-2.0 )"
+SLOT="0"
+KEYWORDS=""
+
+IUSE=""
+
+EGIT_REPO_URI="git://github.com/rust-lang/cargo.git"
+
+DEPEND=">=virtual/rust-999"
+RDEPEND="${DEPEND}"
+
+src_prepare() {
+	CFG_DISABLE_LDCONFIG="true" ./.travis.install.deps.sh || die
+}
+
+src_configure() {
+	./configure \
+		--local-rust-root="${PWD}/rustc" \
+		--prefix="${EPREFIX}"/usr \
+		--disable-verify-install \
+	|| die
+}
+
+src_install() {
+	CFG_DISABLE_LDCONFIG="true" emake DESTDIR="${D}" install || die
+}


### PR DESCRIPTION
The ebuild calls `.travis.install.deps.sh` to fetch "those specific rustc" which can build cargo. The problem is that script fetches rust images for both platforms.
Also this ebuild does not require ldconfig patch because it use `CFG_DISABLE_LDCONFIG="true"` when necessary.

If this unnecessary fetches troubles you. I can try to reduce it to one fetch based on how sh script works.
However ebuild works and emerges workable version of cargo. So if it's OK you may pull changes.