### PR TITLE
dev-util/racer-9999.ebuild

### DIFF
--- a/dev-util/racer/files/50racer-gentoo.el
+++ b/dev-util/racer/files/50racer-gentoo.el
@@ -1,0 +1,3 @@
+(add-to-list 'load-path "@SITELISP@")
+(setq racer-cmd "/usr/bin/racer")
+(eval-after-load "rust-mode" '(require 'racer))

--- a/dev-util/racer/metadata.xml
+++ b/dev-util/racer/metadata.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <maintainer>
+    <email>valahanovich@tut.by</email>
+    <name>Heorhi Valakhanovich</name>
+  </maintainer>
+  <longdescription>
+    Rust Code Completion utility
+  </longdescription>
+  <use>
+    <flag name="emacs"> install emacs script </flag>
+    <flag name="vim"> install vim plugin </flag>
+  </use>
+</pkgmetadata>

--- a/dev-util/racer/racer-9999.ebuild
+++ b/dev-util/racer/racer-9999.ebuild
@@ -1,0 +1,71 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+inherit eutils git-r3 elisp-common
+
+DESCRIPTION="Rust Code Completion utility "
+HOMEPAGE="https://github.com/phildawes/racer"
+IUSE="emacs vim"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS=""
+
+IUSE="emacs vim"
+
+EGIT_REPO_URI="git://github.com/phildawes/racer"
+
+RDEPEND="dev-lang/rust
+	emacs? (
+		app-emacs/company-mode[ropemacs]
+		app-emacs/rust-mode
+		virtual/emacs )
+	vim? ( || ( app-editors/vim app-editors/gvim ) )"
+DEPEND="${RDEPEND}
+	dev-rust/cargo"
+
+src_configure() {
+	cargo build --release
+}
+
+src_install() {
+	$
+	dobin target/release/racer
+	if use emacs; then
+		elisp-install ${PN} editors/racer.el
+		elisp-site-file-install "${FILESDIR}/50${PN}-gentoo.el"
+	fi
+	if use vim; then
+		insinto /usr/share/vim/vimfiles/plugin/
+		sed -i 's|\(g:racer_cmd = \).*|\1"/usr/bin/racer"|' plugin/racer.vim
+		doins plugin/racer.vim
+
+	fi
+}
+
+pkg_postinst() {
+	elog "You most probably should fetch rust sources for best expirience."
+	elog "Racer will look for sources in path pointed by RUST_SRC_PATH"
+	elog "environment variable. You can use"
+	elog "% export RUST_SRC_PATH=<path to>/rust/src."
+	elog ""
+	if use emacs; then
+		elog "You should use '(setq racer-rust-src-path \"<path-to>/rust/src/\")'"
+		elog "for emacs plugin to be able to find rust sources for racer."
+		elog ""
+		elisp-site-regen
+	fi
+	if use vim; then
+		elog "For vim you can use  'let \$RUST_SRC_PATH=\"<path-to>/rust/src/\"'"
+		elog "if you don't want to use environment variable"
+		elog "You also can use \"set hidden\" or else your buffer will be"
+		elog "unloaded on every goto-definition"
+	fi
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
+}


### PR DESCRIPTION
The ebuild installs racer itself and also can install emacs and vim
plugins.

I've marked myself as maintainer just for repoman tests. I'm ready for any objections about this.
We can try to use use-flag for fetching sources automatically. I'll think about it later.
Emacs plugin uses company-mode which has some strange settings for background colors. If others will have problems with that I should probably write a notice in elog.