### PR TITLE
Cargo 32 bit fix

### DIFF
--- a/dev-rust/cargo/cargo-9999-r1.ebuild
+++ b/dev-rust/cargo/cargo-9999-r1.ebuild
@@ -18,12 +18,12 @@ IUSE=""
 EGIT_REPO_URI="git://github.com/rust-lang/cargo.git"
 
 RDEPEND=">=virtual/rust-999"
-DEPEND="${DEPEND} 
+DEPEND="${DEPEND}
 	dev-util/cmake"
 
 src_prepare() {
 	use x86 && export BITS=32
-	CFG_DISABLE_LDCONFIG="true" ./.travis.install.deps.sh || die
+	CFG_DISABLE_LDCONFIG="nonempty" ./.travis.install.deps.sh || die
 }
 
 src_configure() {

--- a/dev-rust/cargo/cargo-9999-r1.ebuild
+++ b/dev-rust/cargo/cargo-9999-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2015 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
@@ -17,10 +17,12 @@ IUSE=""
 
 EGIT_REPO_URI="git://github.com/rust-lang/cargo.git"
 
-DEPEND=">=virtual/rust-999"
-RDEPEND="${DEPEND}"
+RDEPEND=">=virtual/rust-999"
+DEPEND="${DEPEND} 
+	dev-util/cmake"
 
 src_prepare() {
+	use x86 && export BITS=32
 	CFG_DISABLE_LDCONFIG="true" ./.travis.install.deps.sh || die
 }
 


### PR DESCRIPTION
Aparently ./.travis.install.deps.sh needs BITS variable to be set (at
least for x86). Workaround was added.

Probably fixes #61 