### PR TITLE
Fix qa issue with emacs vim-syntax and zsh-completion use flags

### DIFF
--- a/dev-lang/rust-bin/rust-bin-999-r1.ebuild
+++ b/dev-lang/rust-bin/rust-bin-999-r1.ebuild
@@ -14,7 +14,7 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4 UoI-NCSA"
 SLOT="0"
 KEYWORDS=""
 
-IUSE="emacs vim-syntax zsh-completion"
+IUSE=""
 
 CDEPEND=">=app-admin/eselect-rust-0.2_pre20141128
 	!dev-lang/rust:0
@@ -23,9 +23,6 @@ DEPEND="${CDEPEND}
 	net-misc/wget
 "
 RDEPEND="${CDEPEND}
-	emacs? ( >=app-emacs/rust-mode-${PV} )
-	vim-syntax? ( >=app-vim/rust-mode-${PV} )
-	zsh-completion? ( >=app-shells/rust-zshcomp-${PV} )
 "
 
 src_unpack() {
@@ -78,6 +75,18 @@ pkg_postinst() {
 
 	elog "Rust installs a helper script for calling GDB now,"
 	elog "for your convenience it is installed under /usr/bin/rust-gdb-bin-${PV},"
+
+	if has_version app-editors/emacs || has_version app-editors/emacs-vcs; then
+		elog "install app-emacs/rust-mode to get emacs support for rust."
+	fi
+
+	if has_version app-editors/gvim || has_version app-editors/vim; then
+		elog "install app-vim/rust-mode to get vim support for rust."
+	fi
+
+	if has_version 'app-shells/zsh'; then
+		elog "install app-shells/rust-zshcomp to get zsh completion for rust."
+	fi
 }
 
 pkg_postrm() {

--- a/dev-lang/rust-bin/rust-bin-999.ebuild
+++ b/dev-lang/rust-bin/rust-bin-999.ebuild
@@ -14,7 +14,7 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4 UoI-NCSA"
 SLOT="0"
 KEYWORDS=""
 
-IUSE="emacs vim-syntax zsh-completion"
+IUSE=""
 
 CDEPEND=">=app-admin/eselect-rust-0.2_pre20141128
 	!dev-lang/rust:0
@@ -23,9 +23,6 @@ DEPEND="${CDEPEND}
 	net-misc/wget
 "
 RDEPEND="${CDEPEND}
-	emacs? ( >=app-emacs/rust-mode-${PV} )
-	vim-syntax? ( >=app-vim/rust-mode-${PV} )
-	zsh-completion? ( >=app-shells/rust-zshcomp-${PV} )
 "
 
 src_unpack() {
@@ -80,6 +77,18 @@ pkg_postinst() {
 	elog "for your convenience it is installed under /usr/bin/rust-lldb-bin-${PV},"
 	elog "but note, that there is no LLDB ebuild in the tree currently,"
 	elog "so you are on your own if you want to use it."
+
+	if has_version app-editors/emacs || has_version app-editors/emacs-vcs; then
+		elog "install app-emacs/rust-mode to get emacs support for rust."
+	fi
+
+	if has_version app-editors/gvim || has_version app-editors/vim; then
+		elog "install app-vim/rust-mode to get vim support for rust."
+	fi
+
+	if has_version 'app-shells/zsh'; then
+		elog "install app-shells/rust-zshcomp to get zsh completion for rust."
+	fi
 }
 
 pkg_postrm() {

--- a/dev-lang/rust/rust-1.0.0_alpha.ebuild
+++ b/dev-lang/rust/rust-1.0.0_alpha.ebuild
@@ -20,7 +20,7 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4 UoI-NCSA"
 SLOT="1.0"
 KEYWORDS="~amd64 ~x86"
 
-IUSE="clang debug emacs libcxx +system-llvm vim-syntax zsh-completion"
+IUSE="clang debug libcxx +system-llvm"
 REQUIRED_USE="libcxx? ( clang )"
 
 CDEPEND="libcxx? ( sys-libs/libcxx )
@@ -35,9 +35,6 @@ DEPEND="${CDEPEND}
 	system-llvm? ( >=sys-devel/llvm-3.6.0[multitarget(-)] )
 "
 RDEPEND="${CDEPEND}
-	emacs? ( >=app-emacs/rust-mode-${PV} )
-	vim-syntax? ( >=app-vim/rust-mode-${PV} )
-	zsh-completion? ( >=app-shells/rust-zshcomp-${PV} )
 "
 
 S=${WORKDIR}/${MY_PV}
@@ -123,6 +120,18 @@ pkg_postinst() {
 
 	elog "Rust installs a helper script for calling GDB now,"
 	elog "for your convenience it is installed under /usr/bin/rust-gdb-${PV}."
+
+	if has_version app-editors/emacs || has_version app-editors/emacs-vcs; then
+		elog "install app-emacs/rust-mode to get emacs support for rust."
+	fi
+
+	if has_version app-editors/gvim || has_version app-editors/vim; then
+		elog "install app-vim/rust-mode to get vim support for rust."
+	fi
+
+	if has_version 'app-shells/zsh'; then
+		elog "install app-shells/rust-zshcomp to get zsh completion for rust."
+	fi
 }
 
 pkg_postrm() {

--- a/dev-lang/rust/rust-999-r1.ebuild
+++ b/dev-lang/rust/rust-999-r1.ebuild
@@ -18,7 +18,7 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4 UoI-NCSA"
 SLOT="nightly"
 KEYWORDS=""
 
-IUSE="clang debug emacs libcxx +system-llvm vim-syntax zsh-completion"
+IUSE="clang debug libcxx +system-llvm"
 REQUIRED_USE="libcxx? ( clang )"
 
 CDEPEND="libcxx? ( sys-libs/libcxx )
@@ -33,9 +33,6 @@ DEPEND="${CDEPEND}
 	system-llvm? ( >=sys-devel/llvm-3.6.0[multitarget(-)] )
 "
 RDEPEND="${CDEPEND}
-	emacs? ( >=app-emacs/rust-mode-${PV} )
-	vim-syntax? ( >=app-vim/rust-mode-${PV} )
-	zsh-completion? ( >=app-shells/rust-zshcomp-${PV} )
 "
 
 S="${WORKDIR}/${MY_P}"
@@ -116,6 +113,18 @@ pkg_postinst() {
 	elog "for your convenience it is installed under /usr/bin/rust-lldb-${PV},"
 	elog "but note, that there is no LLDB ebuild in the tree currently,"
 	elog "so you are on your own if you want to use it."
+
+	if has_version app-editors/emacs || has_version app-editors/emacs-vcs; then
+		elog "install app-emacs/rust-mode to get emacs support for rust."
+	fi
+
+	if has_version app-editors/gvim || has_version app-editors/vim; then
+		elog "install app-vim/rust-mode to get vim support for rust."
+	fi
+
+	if has_version 'app-shells/zsh'; then
+		elog "install app-shells/rust-zshcomp to get zsh completion for rust."
+	fi
 }
 
 pkg_postrm() {

--- a/dev-lang/rust/rust-999-r2.ebuild
+++ b/dev-lang/rust/rust-999-r2.ebuild
@@ -18,7 +18,7 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4 UoI-NCSA"
 SLOT="nightly"
 KEYWORDS=""
 
-IUSE="clang debug emacs libcxx +system-llvm vim-syntax zsh-completion"
+IUSE="clang debug libcxx +system-llvm"
 REQUIRED_USE="libcxx? ( clang )"
 
 CDEPEND="libcxx? ( sys-libs/libcxx )
@@ -33,9 +33,6 @@ DEPEND="${CDEPEND}
 	system-llvm? ( >=sys-devel/llvm-3.6.0[multitarget(-)] )
 "
 RDEPEND="${CDEPEND}
-	emacs? ( >=app-emacs/rust-mode-${PV} )
-	vim-syntax? ( >=app-vim/rust-mode-${PV} )
-	zsh-completion? ( >=app-shells/rust-zshcomp-${PV} )
 "
 
 S="${WORKDIR}/${MY_P}"
@@ -124,6 +121,18 @@ pkg_postinst() {
 
 	elog "Rust installs a helper script for calling GDB now,"
 	elog "for your convenience it is installed under /usr/bin/rust-gdb-${PV}."
+
+	if has_version app-editors/emacs || has_version app-editors/emacs-vcs; then
+		elog "install app-emacs/rust-mode to get emacs support for rust."
+	fi
+
+	if has_version app-editors/gvim || has_version app-editors/vim; then
+		elog "install app-vim/rust-mode to get vim support for rust."
+	fi
+
+	if has_version 'app-shells/zsh'; then
+		elog "install app-shells/rust-zshcomp to get zsh completion for rust."
+	fi
 }
 
 pkg_postrm() {

--- a/dev-lang/rust/rust-9999-r3.ebuild
+++ b/dev-lang/rust/rust-9999-r3.ebuild
@@ -16,7 +16,7 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4 UoI-NCSA"
 SLOT="git"
 KEYWORDS=""
 
-IUSE="clang debug emacs libcxx +system-llvm vim-syntax zsh-completion"
+IUSE="clang debug libcxx +system-llvm"
 REQUIRED_USE="libcxx? ( clang )"
 
 CDEPEND="libcxx? ( sys-libs/libcxx )
@@ -30,9 +30,6 @@ DEPEND="${CDEPEND}
 	system-llvm? ( >=sys-devel/llvm-3.6.0[multitarget(-)] )
 "
 RDEPEND="${CDEPEND}
-	emacs? ( >=app-emacs/rust-mode-${PV} )
-	vim-syntax? ( >=app-vim/rust-mode-${PV} )
-	zsh-completion? ( >=app-shells/rust-zshcomp-${PV} )
 "
 
 src_unpack() {
@@ -116,6 +113,18 @@ pkg_postinst() {
 	elog "for your convenience it is installed under /usr/bin/rust-lldb-${PV},"
 	elog "but note, that there is no LLDB ebuild in the tree currently,"
 	elog "so you are on your own if you want to use it."
+
+	if has_version app-editors/emacs || has_version app-editors/emacs-vcs; then
+		elog "install app-emacs/rust-mode to get emacs support for rust."
+	fi
+
+	if has_version app-editors/gvim || has_version app-editors/vim; then
+		elog "install app-vim/rust-mode to get vim support for rust."
+	fi
+
+	if has_version 'app-shells/zsh'; then
+		elog "install app-shells/rust-zshcomp to get zsh completion for rust."
+	fi
 }
 
 pkg_postrm() {


### PR DESCRIPTION
Gentoo qa policy does not allow use flags to pull in optional runtime
dependencies the package does not link to, so We need to remove the
emacs, vim-syntax and zsh-completion use flags from the dev-lang/rust*
ebuilds [1]. We can, however, output elog messages to the user based on
what they have installed.

[1] https://devmanual.gentoo.org/general-concepts/use-flags/index.html