### PR TITLE
Do not quote the EAPI value

### DIFF
--- a/app-emacs/rust-mode/rust-mode-1.0.0_alpha.ebuild
+++ b/app-emacs/rust-mode/rust-mode-1.0.0_alpha.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
-EAPI="5"
+EAPI=5
 
 inherit elisp
 

--- a/app-emacs/rust-mode/rust-mode-9999.ebuild
+++ b/app-emacs/rust-mode/rust-mode-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
-EAPI="5"
+EAPI=5
 
 inherit elisp git-r3
 

--- a/app-shells/rust-zshcomp/rust-zshcomp-1.0.0_alpha.ebuild
+++ b/app-shells/rust-zshcomp/rust-zshcomp-1.0.0_alpha.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
-EAPI="5"
+EAPI=5
 
 MY_PV="rustc-1.0.0-alpha"
 DESCRIPTION="Rust zsh completions"

--- a/app-shells/rust-zshcomp/rust-zshcomp-9999.ebuild
+++ b/app-shells/rust-zshcomp/rust-zshcomp-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
-EAPI="5"
+EAPI=5
 
 inherit git-r3
 

--- a/app-vim/rust-mode/rust-mode-1.0.0_alpha.ebuild
+++ b/app-vim/rust-mode/rust-mode-1.0.0_alpha.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
-EAPI="5"
+EAPI=5
 
 inherit vim-plugin
 

--- a/app-vim/rust-mode/rust-mode-9999.ebuild
+++ b/app-vim/rust-mode/rust-mode-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
-EAPI="5"
+EAPI=5
 
 inherit vim-plugin git-r3
 

--- a/dev-lang/rust-bin/rust-bin-999.ebuild
+++ b/dev-lang/rust-bin/rust-bin-999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
-EAPI="5"
+EAPI=5
 
 inherit eutils
 

--- a/dev-lang/rust/rust-1.0.0_alpha.ebuild
+++ b/dev-lang/rust/rust-1.0.0_alpha.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
-EAPI="5"
+EAPI=5
 
 PYTHON_COMPAT=( python{2_6,2_7} )
 

--- a/dev-lang/rust/rust-999.ebuild
+++ b/dev-lang/rust/rust-999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
-EAPI="5"
+EAPI=5
 
 PYTHON_COMPAT=( python{2_6,2_7} )
 

--- a/dev-lang/rust/rust-9999.ebuild
+++ b/dev-lang/rust/rust-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
-EAPI="5"
+EAPI=5
 
 PYTHON_COMPAT=( python{2_6,2_7} )
 


### PR DESCRIPTION
The EAPI value doesn't need to be quoted since it doesn't include
spaces.