### PR TITLE
rust-999.ebuild and rust-9999.ebuild ldconfig fix

### DIFF
--- a/dev-lang/rust/rust-1.0.0_alpha.ebuild
+++ b/dev-lang/rust/rust-1.0.0_alpha.ebuild
@@ -50,7 +50,7 @@ src_prepare() {
 }
 
 src_configure() {
-	export CFG_DISABLE_LDCONFIG="yes"
+	export CFG_DISABLE_LDCONFIG="notempty"
 
 	local system_llvm
 	use system-llvm && system_llvm="--llvm-root=${EPREFIX}/usr"

--- a/dev-lang/rust/rust-999.ebuild
+++ b/dev-lang/rust/rust-999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2015 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
@@ -59,6 +59,7 @@ src_configure() {
 	local system_llvm
 	use system-llvm && system_llvm="--llvm-root=${EPREFIX}/usr"
 
+	export CFG_DISABLE_LDCONFIG="notempty"
 	"${ECONF_SOURCE:-.}"/configure \
 		--prefix="${EPREFIX}/usr" \
 		--libdir="${EPREFIX}/usr/lib/${P}" \

--- a/dev-lang/rust/rust-9999.ebuild
+++ b/dev-lang/rust/rust-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2015 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
@@ -53,6 +53,7 @@ src_configure() {
 	local system_llvm
 	use system-llvm && system_llvm="--llvm-root=${EPREFIX}/usr"
 
+	export CFG_DISABLE_LDCONFIG="notempty"
 	"${ECONF_SOURCE:-.}"/configure \
 		--prefix="${EPREFIX}/usr" \
 		--libdir="${EPREFIX}/usr/lib/${P}" \


### PR DESCRIPTION
Little addition to 2106e48dfd2acfb2893db54dd0dcbd63d286d3bf which
disable ldconfig for live ebuilds.