### PR TITLE
Problem: Some ebuilds were using the insecure git:// url scheme

### DIFF
--- a/dev-lang/rust/rust-9999.ebuild
+++ b/dev-lang/rust/rust-9999.ebuild
@@ -10,7 +10,7 @@ inherit eutils git-r3 python-any-r1
 
 DESCRIPTION="Systems programming language from Mozilla"
 HOMEPAGE="http://www.rust-lang.org/"
-EGIT_REPO_URI="git://github.com/rust-lang/rust.git"
+EGIT_REPO_URI="https://github.com/rust-lang/rust.git"
 
 LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4 UoI-NCSA"
 SLOT="git"

--- a/dev-rust/cargo/cargo-9999.ebuild
+++ b/dev-rust/cargo/cargo-9999.ebuild
@@ -15,7 +15,7 @@ KEYWORDS=""
 
 IUSE=""
 
-EGIT_REPO_URI="git://github.com/rust-lang/cargo.git"
+EGIT_REPO_URI="https://github.com/rust-lang/cargo.git"
 
 RDEPEND=">=virtual/rust-999"
 DEPEND="${DEPEND}

--- a/dev-rust/rust-bindgen/rust-bindgen-9999.ebuild
+++ b/dev-rust/rust-bindgen/rust-bindgen-9999.ebuild
@@ -15,7 +15,7 @@ KEYWORDS=""
 
 IUSE=""
 
-EGIT_REPO_URI="git://github.com/crabtw/rust-bindgen.git"
+EGIT_REPO_URI="https://github.com/crabtw/rust-bindgen.git"
 
 DEPEND=">=virtual/rust-999
 	dev-rust/cargo

--- a/dev-util/racer/racer-9999.ebuild
+++ b/dev-util/racer/racer-9999.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 KEYWORDS=""
 IUSE="emacs vim"
 
-EGIT_REPO_URI="git://github.com/phildawes/racer"
+EGIT_REPO_URI="https://github.com/phildawes/racer"
 
 COMMON_DEPEND="dev-lang/rust
 	emacs? (


### PR DESCRIPTION
Using https is an improvement to building because at least you can verify that no-one is modifying your git repository in-flight.

This is part of https://github.com/Heather/gentoo-rust/issues/83