### PR TITLE
dev-rust/cargo: add dependencies

### DIFF
--- a/dev-rust/cargo/cargo-9999.ebuild
+++ b/dev-rust/cargo/cargo-9999.ebuild
@@ -17,7 +17,11 @@ IUSE=""
 
 EGIT_REPO_URI="https://github.com/rust-lang/cargo.git"
 
-COMMON_DEPEND=">=virtual/rust-999"
+COMMON_DEPEND=">=virtual/rust-999
+	sys-libs/zlib
+	dev-libs/openssl
+	net-libs/libssh2
+	net-libs/http-parser"
 RDEPEND="${COMMON_DEPEND}
 	net-misc/curl[curl_ssl_openssl]"
 DEPEND="${COMMON_DEPEND}


### PR DESCRIPTION
If this libs are missing from system, cargo will statically link to
its own bundled libs. But if they are present, then there is no way
to prevent cargo dynamically linking against them.