### PR TITLE
remove --disable-verify-install configure option

### DIFF
--- a/dev-lang/rust/rust-999.ebuild
+++ b/dev-lang/rust/rust-999.ebuild
@@ -62,7 +62,6 @@ src_configure() {
 		--libdir="${EPREFIX}/usr/lib/${P}" \
 		--mandir="${EPREFIX}/usr/share/${P}/man" \
 		--disable-manage-submodules \
-		--disable-verify-install \
 		$(use_enable clang) \
 		$(use_enable debug) \
 		$(use_enable debug llvm-assertions) \

--- a/dev-lang/rust/rust-9999.ebuild
+++ b/dev-lang/rust/rust-9999.ebuild
@@ -56,7 +56,6 @@ src_configure() {
 		--libdir="${EPREFIX}/usr/lib/${P}" \
 		--mandir="${EPREFIX}/usr/share/${P}/man" \
 		--disable-manage-submodules \
-		--disable-verify-install \
 		$(use_enable clang) \
 		$(use_enable debug) \
 		$(use_enable debug llvm-assertions) \


### PR DESCRIPTION
Upstream has removed the --disable-verify-install option from the
configure script and therefore specifying it causes configure to fail

upstream commit: rust-lang/rust@bc9f16c59960cfb306178428956f8446337d27e7