### PR TITLE
Add --release-channel to ./configure options

### DIFF
--- a/dev-lang/rust/rust-1.0.0_beta.ebuild
+++ b/dev-lang/rust/rust-1.0.0_beta.ebuild
@@ -8,11 +8,18 @@ PYTHON_COMPAT=( python2_7 )
 
 inherit eutils python-any-r1
 
-MY_PV="rustc-1.0.0-beta"
+RUST_CHANNEL="beta"
+
+BETA_NUM="${PV##*beta}"
+MY_PV="${PV/_/-}"
+# beta => beta BUT beta2 => beta.2
+[ -n "${BETA_NUM}" ] && MY_PV="${MY_PV/beta/beta.}"
+MY_P="rustc-${MY_PV}"
+
 DESCRIPTION="Systems programming language from Mozilla"
 HOMEPAGE="http://www.rust-lang.org/"
 
-SRC_URI="http://static.rust-lang.org/dist/${MY_PV}-src.tar.gz
+SRC_URI="http://static.rust-lang.org/dist/${MY_P}-src.tar.gz
 	x86?   ( http://static.rust-lang.org/stage0-snapshots/rust-stage0-2015-03-27-5520801-linux-i386-1ef82402ed16f5a6d2f87a9a62eaa83170e249ec.tar.bz2 )
 	amd64? ( http://static.rust-lang.org/stage0-snapshots/rust-stage0-2015-03-27-5520801-linux-x86_64-ef2154372e97a3cb687897d027fd51c8f2c5f349.tar.bz2 )"
 
@@ -36,12 +43,12 @@ DEPEND="${CDEPEND}
 RDEPEND="${CDEPEND}
 "
 
-S=${WORKDIR}/${MY_PV}
+S=${WORKDIR}/${MY_P}
 
 src_unpack() {
-	unpack "${MY_PV}-src.tar.gz" || die
-	mkdir "${MY_PV}/dl" || die
-	cp "${DISTDIR}/rust-stage0"* "${MY_PV}/dl/" || die
+	unpack "${MY_P}-src.tar.gz" || die
+	mkdir "${MY_P}/dl" || die
+	cp "${DISTDIR}/rust-stage0"* "${MY_P}/dl/" || die
 }
 
 src_prepare() {
@@ -56,6 +63,7 @@ src_configure() {
 		--prefix="${EPREFIX}/usr" \
 		--libdir="${EPREFIX}/usr/lib/${P}" \
 		--mandir="${EPREFIX}/usr/share/${P}/man" \
+		--release-channel=${RUST_CHANNEL} \
 		--disable-manage-submodules \
 		--disable-verify-install \
 		$(use_enable clang) \

--- a/dev-lang/rust/rust-1.0.0_beta2.ebuild
+++ b/dev-lang/rust/rust-1.0.0_beta2.ebuild
@@ -8,11 +8,18 @@ PYTHON_COMPAT=( python2_7 )
 
 inherit eutils python-any-r1
 
-MY_PV="rustc-1.0.0-beta.2"
+RUST_CHANNEL="beta"
+
+BETA_NUM="${PV##*beta}"
+MY_PV="${PV/_/-}"
+# beta => beta BUT beta2 => beta.2
+[ -n "${BETA_NUM}" ] && MY_PV="${MY_PV/beta/beta.}"
+MY_P="rustc-${MY_PV}"
+
 DESCRIPTION="Systems programming language from Mozilla"
 HOMEPAGE="http://www.rust-lang.org/"
 
-SRC_URI="http://static.rust-lang.org/dist/${MY_PV}-src.tar.gz
+SRC_URI="http://static.rust-lang.org/dist/${MY_P}-src.tar.gz
 	x86?   ( http://static.rust-lang.org/stage0-snapshots/rust-stage0-2015-03-27-5520801-linux-i386-1ef82402ed16f5a6d2f87a9a62eaa83170e249ec.tar.bz2 )
 	amd64? ( http://static.rust-lang.org/stage0-snapshots/rust-stage0-2015-03-27-5520801-linux-x86_64-ef2154372e97a3cb687897d027fd51c8f2c5f349.tar.bz2 )"
 
@@ -36,12 +43,12 @@ DEPEND="${CDEPEND}
 RDEPEND="${CDEPEND}
 "
 
-S=${WORKDIR}/${MY_PV}
+S=${WORKDIR}/${MY_P}
 
 src_unpack() {
-	unpack "${MY_PV}-src.tar.gz" || die
-	mkdir "${MY_PV}/dl" || die
-	cp "${DISTDIR}/rust-stage0"* "${MY_PV}/dl/" || die
+	unpack "${MY_P}-src.tar.gz" || die
+	mkdir "${MY_P}/dl" || die
+	cp "${DISTDIR}/rust-stage0"* "${MY_P}/dl/" || die
 }
 
 src_prepare() {
@@ -56,6 +63,7 @@ src_configure() {
 		--prefix="${EPREFIX}/usr" \
 		--libdir="${EPREFIX}/usr/lib/${P}" \
 		--mandir="${EPREFIX}/usr/share/${P}/man" \
+		--release-channel=${RUST_CHANNEL} \
 		--disable-manage-submodules \
 		$(use_enable clang) \
 		$(use_enable debug) \

--- a/dev-lang/rust/rust-999.ebuild
+++ b/dev-lang/rust/rust-999.ebuild
@@ -8,6 +8,8 @@ PYTHON_COMPAT=( python2_7 )
 
 inherit eutils python-any-r1
 
+RUST_CHANNEL="nightly"
+
 MY_P=rustc-nightly
 
 DESCRIPTION="Systems programming language from Mozilla"
@@ -61,6 +63,7 @@ src_configure() {
 		--prefix="${EPREFIX}/usr" \
 		--libdir="${EPREFIX}/usr/lib/${P}" \
 		--mandir="${EPREFIX}/usr/share/${P}/man" \
+		--release-channel=${RUST_CHANNEL} \
 		--disable-manage-submodules \
 		$(use_enable clang) \
 		$(use_enable debug) \


### PR DESCRIPTION
... plus some refactoring.
As @himikof mentioned comment to #95, the main difference is that without this flag unstable features are enabled in beta build.