### PR TITLE
[cargo] make cargo-0.2 ebuild work with current beta

### DIFF
--- a/dev-rust/cargo/cargo-0.2.0.ebuild
+++ b/dev-rust/cargo/cargo-0.2.0.ebuild
@@ -27,7 +27,7 @@ IUSE=""
 EGIT_REPO_URI="https://github.com/rust-lang/cargo.git"
 EGIT_COMMIT="${PV}"
 
-COMMON_DEPEND=">=virtual/rust-999
+COMMON_DEPEND=">=virtual/rust-1.0
 	sys-libs/zlib
 	dev-libs/openssl:*
 	net-libs/libssh2


### PR DESCRIPTION
It would be nice to have a cargo version, which doesn't pull in nightly rust versions. As cargo-0.2 works fine with the current beta version, I see no need to depend on the nightly version of virtual/rust.