### PR TITLE
[dev-lang/rust-bin] fix ebuilds

### DIFF
--- a/dev-lang/rust-bin/rust-bin-1.0.0_beta2.ebuild
+++ b/dev-lang/rust-bin/rust-bin-1.0.0_beta2.ebuild
@@ -42,7 +42,8 @@ src_install() {
 		--disable-verify \
 		--prefix="${D}/opt/${P}" \
 		--mandir="${D}/usr/share/${P}/man" \
-		--disable-ldconfig
+		--disable-ldconfig \
+		|| die
 
 	local rustc=rustc-bin-${PV}
 	local rustdoc=rustdoc-bin-${PV}

--- a/dev-lang/rust-bin/rust-bin-1.0.0_beta3.ebuild
+++ b/dev-lang/rust-bin/rust-bin-1.0.0_beta3.ebuild
@@ -19,12 +19,10 @@ SRC_URI="amd64? ( http://static.rust-lang.org/dist/${MY_P}-x86_64-unknown-linux-
 LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4 UoI-NCSA"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-
-IUSE="cargo-bundled doc"
+IUSE=""
 
 DEPEND=">=app-eselect/eselect-rust-0.3_pre20150425
 	!dev-lang/rust:0
-	cargo-bundled? ( !dev-rust/cargo )
 "
 RDEPEND="${DEPEND}"
 
@@ -39,14 +37,13 @@ src_unpack() {
 
 src_install() {
 	local components=rustc
-	use cargo-bundled && components="${components},cargo"
-	use doc && components="${components},rust-docs"
 	./install.sh \
 		--components="${components}" \
 		--disable-verify \
 		--prefix="${D}/opt/${P}" \
 		--mandir="${D}/usr/share/${P}/man" \
-		--disable-ldconfig
+		--disable-ldconfig \
+		|| die
 
 	local rustc=rustc-bin-${PV}
 	local rustdoc=rustdoc-bin-${PV}
@@ -73,13 +70,6 @@ src_install() {
 	dodir /etc/env.d/rust
 	insinto /etc/env.d/rust
 	doins "${T}/provider-${P}"
-
-	if use cargo-bundled ; then
-		dosym "/opt/${P}/bin/cargo" /usr/bin/cargo
-		dosym "/opt/${P}/share/zsh/site-functions/_cargo" /usr/share/zsh/site-functions/_cargo
-		newbashcomp "${D}/opt/${P}/etc/bash_completion.d/cargo" cargo
-		rm -rf "${D}/opt/${P}/etc"
-	fi
 }
 
 pkg_postinst() {

--- a/dev-lang/rust-bin/rust-bin-999.ebuild
+++ b/dev-lang/rust-bin/rust-bin-999.ebuild
@@ -46,7 +46,8 @@ src_install() {
 		--disable-verify \
 		--prefix="${D}/opt/${P}" \
 		--mandir="${D}/usr/share/${P}/man" \
-		--disable-ldconfig
+		--disable-ldconfig \
+		|| die
 
 	local rustc=rustc-bin-${PV}
 	local rustdoc=rustdoc-bin-${PV}


### PR DESCRIPTION
dev-lang/rust-bin-1.0.0_beta3 doesn't have docs and cargo, removing USEs
add || die to install script invocation