### PR TITLE
Fix cargo build when dev-libs/libgit2 is installed (#124)

### DIFF
--- a/dev-rust/cargo/cargo-9999.ebuild
+++ b/dev-rust/cargo/cargo-9999.ebuild
@@ -31,6 +31,10 @@ src_configure() {
 	./configure --prefix="${EPREFIX}"/usr --disable-verify-install || die
 }
 
+src_compile() {
+	emake VERBOSE=1 PKG_CONFIG_PATH="" || die
+}
+
 src_install() {
 	CFG_DISABLE_LDCONFIG="true" emake DESTDIR="${D}" install || die
 	dobashcomp "${ED}"/usr/etc/bash_completion.d/cargo


### PR DESCRIPTION
This is a temporary workaround for the bug in `git2-rs` build script, which is already fixed in the upstream (alexcrichton/git2-rs#63) but will take time to land in cargo. 