### PR TITLE
Fix build when using sudo and Palidus

### DIFF
--- a/dev-lang/rust/rust-1.0.0.ebuild
+++ b/dev-lang/rust/rust-1.0.0.ebuild
@@ -83,6 +83,8 @@ src_compile() {
 }
 
 src_install() {
+	unset SUDO_USER
+
 	default
 
 	mv "${D}/usr/bin/rustc" "${D}/usr/bin/rustc-${PV}" || die


### PR DESCRIPTION
When running install, the Rust build system tries to be clever and drop privileges for part of the process by sudoing back to $SUDO_USER, if it is set. Unfortunately, this breaks when the contents of $SUDO_USER (my username) doesn't match the user used to unpack and build the compiler (paludisbuild), resulting in a permission denied error during the install step. The simplest solution is just to unset SUDO_USER.