### PR TITLE
[dev-rust/cargo] depend on curl[ssl] rather than curl[curl_ssl_openssl]

### DIFF
--- a/dev-rust/cargo/cargo-0.2.0.ebuild
+++ b/dev-rust/cargo/cargo-0.2.0.ebuild
@@ -78,7 +78,7 @@ COMMON_DEPEND="sys-libs/zlib
 	net-libs/libssh2
 	net-libs/http-parser"
 RDEPEND="${COMMON_DEPEND}
-	net-misc/curl[curl_ssl_openssl]"
+	net-misc/curl[ssl]"
 DEPEND="${COMMON_DEPEND}
 	dev-util/cmake"
 

--- a/dev-rust/cargo/cargo-9999.ebuild
+++ b/dev-rust/cargo/cargo-9999.ebuild
@@ -23,7 +23,7 @@ COMMON_DEPEND=">=virtual/rust-999
 	net-libs/libssh2
 	net-libs/http-parser"
 RDEPEND="${COMMON_DEPEND}
-	net-misc/curl[curl_ssl_openssl]"
+	net-misc/curl[ssl]"
 DEPEND="${COMMON_DEPEND}
 	dev-util/cmake"
 


### PR DESCRIPTION
Should fix #129.

Not tested yet, since downloading all needed stuff takes ages. As soon as I'll be able to confirm that it does help, I'll comment.