### PR TITLE
[dev-rust/cargo] A new and improved ebuild for cargo v0.3.0

### DIFF
--- a/dev-rust/cargo/cargo-0.3.0-r1.ebuild
+++ b/dev-rust/cargo/cargo-0.3.0-r1.ebuild
@@ -81,7 +81,7 @@ COMMON_DEPEND="sys-libs/zlib
 RDEPEND="${COMMON_DEPEND}
 	net-misc/curl[ssl]"
 DEPEND="${COMMON_DEPEND}
-	|| ( >=dev-lang/rust-1.1.0 >=dev-lang/rust-bin-1.1.0 )
+	>=virtual/rust-1.1
 	dev-util/cmake"
 
 PATCHES=(
@@ -153,8 +153,8 @@ src_install() {
 	autotools-utils_src_install VERBOSE=1 CFG_DISABLE_LDCONFIG="true"
 
 	# Install HTML documentation
-	dohtml -r target/doc/*
+	use doc && dohtml -r target/doc/*
 
 	dobashcomp "${ED}"/usr/etc/bash_completion.d/cargo
-	rm -rf "${ED}"/usr/etc || die
+	rm -r "${ED}"/usr/etc || die
 }

--- a/dev-rust/cargo/files/cargo-0.3.0-makefile.patch
+++ b/dev-rust/cargo/files/cargo-0.3.0-makefile.patch
@@ -1,7 +1,7 @@
-diff --git a/cargo-0.2.0/Makefile.in b/cargo-0.2.0/Makefile.in
+diff --git a/cargo-0.3.0/Makefile.in b/cargo-0.3.0/Makefile.in
 index 467df7d..4527b5a 100644
---- a/Makefile.in
-+++ b/Makefile.in
+--- a/cargo-0.3.0/Makefile.in
++++ b/cargo-0.3.0/Makefile.in
 @@ -17,10 +17,14 @@ else
  CFG_RELEASE=$(CFG_RELEASE_NUM)$(CFG_RELEASE_LABEL)
  CFG_PACKAGE_VERS=$(CFG_RELEASE)
@@ -16,5 +16,5 @@ index 467df7d..4527b5a 100644
  CFG_VERSION = $(CFG_RELEASE) ($(CFG_VER_HASH) $(CFG_VER_DATE)) (built $(CFG_BUILD_DATE))
 +endif
  PKG_NAME = cargo-$(CFG_PACKAGE_VERS)
- 
+
  ifdef CFG_DISABLE_VERIFY_INSTALL

--- a/virtual/rust/rust-1.1.ebuild
+++ b/virtual/rust/rust-1.1.ebuild
@@ -3,14 +3,13 @@
 # $Header: $
 
 EAPI=5
-inherit versionator
 
 DESCRIPTION="Virtual for Rust language compiler"
 HOMEPAGE=""
 SRC_URI=""
 
 LICENSE=""
-SLOT="0/$(get_version_component_range 1-2 ${PV})"
+SLOT="0"
 KEYWORDS="~amd64 ~x86"
 
 DEPEND=""

--- a/virtual/rust/rust-1.1.ebuild
+++ b/virtual/rust/rust-1.1.ebuild
@@ -3,14 +3,19 @@
 # $Header: $
 
 EAPI=5
+inherit versionator
 
 DESCRIPTION="Virtual for Rust language compiler"
 HOMEPAGE=""
 SRC_URI=""
 
 LICENSE=""
-SLOT="0"
+SLOT="0/$(get_version_component_range 1-2 ${PV})"
 KEYWORDS="~amd64 ~x86"
 
 DEPEND=""
-RDEPEND="=dev-lang/rust-${PV}*"
+RDEPEND="
+|| (
+	=dev-lang/rust-${PV}*:${SLOT}
+	=dev-lang/rust-bin-${PV}*:${SLOT}
+)"

--- a/virtual/rust/rust-1.1.ebuild
+++ b/virtual/rust/rust-1.1.ebuild
@@ -15,6 +15,6 @@ KEYWORDS="~amd64 ~x86"
 DEPEND=""
 RDEPEND="
 || (
-	=dev-lang/rust-${PV}*:${SLOT}
-	=dev-lang/rust-bin-${PV}*:${SLOT}
+	=dev-lang/rust-${PV}*
+	=dev-lang/rust-bin-${PV}*
 )"

--- a/virtual/rust/rust-999.ebuild
+++ b/virtual/rust/rust-999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2015 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 

--- a/virtual/rust/rust-9999.ebuild
+++ b/virtual/rust/rust-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2015 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 


### PR DESCRIPTION
- Rustc snapshot has been removed because redundant and not used during
  the compilation phase;
- Ebuild uses 'autotools-utils' eclass instead of relying on manual
  emake/einstall invocations;
- Ebuild uses virtual/rust;
- Add missing 'die';
- Add USE flag 'doc';
- Fix /usr/share/doc hard-coded paths;
- Configure phase properly honours CTARGETs supported by Rust/Cargo;