### PR TITLE
Use virtual/rust instead of dev-lang/rust

### DIFF
--- a/dev-util/SolidOak/SolidOak-9999.ebuild
+++ b/dev-util/SolidOak/SolidOak-9999.ebuild
@@ -17,7 +17,7 @@ IUSE=""
 
 EGIT_REPO_URI="https://github.com/oakes/SolidOak.git"
 
-RDEPEND="dev-lang/rust:*
+RDEPEND="virtual/rust:*
 	dev-util/racer
 	x11-libs/vte:2.90
 	app-editors/neovim

--- a/dev-util/cargo/cargo-0.6.0.ebuild
+++ b/dev-util/cargo/cargo-0.6.0.ebuild
@@ -91,7 +91,7 @@ RDEPEND="${COMMON_DEPEND}
 	!dev-util/cargo-bin
 	net-misc/curl[ssl]"
 DEPEND="${COMMON_DEPEND}
-	|| ( >=dev-lang/rust-1.1.0 >=dev-lang/rust-bin-1.1.0 )
+	>=virtual/rust-1.1.0
 	dev-util/cmake"
 
 PATCHES=(

--- a/dev-util/racer/racer-9999.ebuild
+++ b/dev-util/racer/racer-9999.ebuild
@@ -16,7 +16,7 @@ IUSE=""
 
 EGIT_REPO_URI="https://github.com/phildawes/racer"
 
-COMMON_DEPEND="dev-lang/rust:*"
+COMMON_DEPEND="virtual/rust:*"
 DEPEND="${COMMON_DEPEND}
 	dev-util/cargo"
 RDEPEND="${COMMON_DEPEND}"
@@ -37,4 +37,3 @@ pkg_postinst() {
 	elog "Use vim-racer or emacs-racer for the editos support"
 	elog
 }
-

--- a/dev-util/rusty-tags/rusty-tags-9999.ebuild
+++ b/dev-util/rusty-tags/rusty-tags-9999.ebuild
@@ -17,7 +17,7 @@ IUSE=""
 
 EGIT_REPO_URI="https://github.com/dan-t/rusty-tags.git"
 
-RDEPEND="dev-lang/rust:*"
+RDEPEND="virtual/rust:*"
 DEPEND="${DEPEND}"
 
 src_compile() {

--- a/virtual/rust/rust-1.3.0.ebuild
+++ b/virtual/rust/rust-1.3.0.ebuild
@@ -1,0 +1,19 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+DESCRIPTION="Virtual for Rust language compiler"
+HOMEPAGE=""
+SRC_URI=""
+
+LICENSE=""
+SLOT="0"
+KEYWORDS=""
+
+DEPEND=""
+RDEPEND="|| (
+	=dev-lang/rust-${PV}*
+	=dev-lang/rust-bin-${PV}*
+)"

--- a/virtual/rust/rust-1.4.0.ebuild
+++ b/virtual/rust/rust-1.4.0.ebuild
@@ -1,0 +1,19 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+DESCRIPTION="Virtual for Rust language compiler"
+HOMEPAGE=""
+SRC_URI=""
+
+LICENSE=""
+SLOT="0"
+KEYWORDS=""
+
+DEPEND=""
+RDEPEND="|| (
+	=dev-lang/rust-${PV}*
+	=dev-lang/rust-bin-${PV}*
+)"


### PR DESCRIPTION
This allows using dev-lang/rust-bin instead.